### PR TITLE
Make changes to the response builder and bump version by one minor patch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.lukaesebrot</groupId>
     <artifactId>javalin-api-library</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <properties>
         <java.version>11</java.version>

--- a/src/main/java/dev/lukaesebrot/jal/endpoints/Endpoint.java
+++ b/src/main/java/dev/lukaesebrot/jal/endpoints/Endpoint.java
@@ -5,6 +5,7 @@ import io.javalin.http.Context;
 
 /**
  * This class is used to simplify the creation of an endpoint
+ *
  * @author Lukas Schulte Pelkum
  * @version 1.0.0
  * @since 1.0.0
@@ -15,6 +16,7 @@ public abstract class Endpoint {
 
     /**
      * Injects the current RateLimiter
+     *
      * @param rateLimiter The RateLimiter instance
      */
     protected void injectRateLimiter(RateLimiter rateLimiter) {
@@ -23,6 +25,7 @@ public abstract class Endpoint {
 
     /**
      * Handles the validation of the request and then calls the final handle method
+     *
      * @param ctx The request context
      */
     protected void execute(Context ctx) {
@@ -38,6 +41,7 @@ public abstract class Endpoint {
 
     /**
      * Gets called if the rate limiting succeeded
+     *
      * @param ctx The request context
      */
     abstract public void handle(Context ctx);

--- a/src/main/java/dev/lukaesebrot/jal/endpoints/HttpServer.java
+++ b/src/main/java/dev/lukaesebrot/jal/endpoints/HttpServer.java
@@ -17,6 +17,7 @@ public class HttpServer {
 
     /**
      * Creates a new HttpServer instance without a {@link RateLimiter}
+     *
      * @param app The Javalin app instance
      */
     public HttpServer(Javalin app) {
@@ -25,7 +26,8 @@ public class HttpServer {
 
     /**
      * Creates a new HttpServer instance with a {@link RateLimiter}
-     * @param app The Javalin app instance
+     *
+     * @param app         The Javalin app instance
      * @param rateLimiter The RateLimiter instance
      */
     public HttpServer(Javalin app, RateLimiter rateLimiter) {
@@ -35,8 +37,9 @@ public class HttpServer {
 
     /**
      * Registers a new {@link Endpoint}
-     * @param path The path of the endpoint
-     * @param type The handler type
+     *
+     * @param path     The path of the endpoint
+     * @param type     The handler type
      * @param endpoint The endpoint object
      */
     public void endpoint(String path, HandlerType type, Endpoint endpoint) {
@@ -46,9 +49,10 @@ public class HttpServer {
 
     /**
      * Registers a new {@link Endpoint}
-     * @param path The path of the endpoint
-     * @param type The handler type
-     * @param endpoint The endpoint object
+     *
+     * @param path           The path of the endpoint
+     * @param type           The handler type
+     * @param endpoint       The endpoint object
      * @param permittedRoles A set of permitted roles
      */
     public void endpoint(String path, HandlerType type, Endpoint endpoint, Set<Role> permittedRoles) {

--- a/src/main/java/dev/lukaesebrot/jal/ratelimiting/RateLimiter.java
+++ b/src/main/java/dev/lukaesebrot/jal/ratelimiting/RateLimiter.java
@@ -11,6 +11,7 @@ import java.util.function.Consumer;
 
 /**
  * This class is used to handle the validation of the amount of requests in a specific time
+ *
  * @author Lukas Schulte Pelkum
  * @version 1.0.0
  * @since 1.0.0
@@ -24,8 +25,9 @@ public class RateLimiter {
 
     /**
      * Creates a new RateLimiter
+     *
      * @param allowedPerMinute The allowed amount of requests per minute per IP
-     * @param onRateLimiting Gets accepted if a requester is being rate limited
+     * @param onRateLimiting   Gets accepted if a requester is being rate limited
      */
     public RateLimiter(long allowedPerMinute, Consumer<Context> onRateLimiting) {
         this.allowedPerMinute = allowedPerMinute;
@@ -41,6 +43,7 @@ public class RateLimiter {
 
     /**
      * Increases the amount of executed requests this minute of the given IP
+     *
      * @param ctx The request context which holds the IP address
      */
     public void notifyIPRequest(Context ctx) {
@@ -49,6 +52,7 @@ public class RateLimiter {
 
     /**
      * Returns whether or not the given IP is being rate limited and executes the rate limiting consumer if needed
+     *
      * @param ctx The request context which holds the IP address
      * @return <code>true</code>, if the IP is allowed to execute the request, <code>false</code> otherwise
      */

--- a/src/main/java/dev/lukaesebrot/jal/responses/ResponseBuilder.java
+++ b/src/main/java/dev/lukaesebrot/jal/responses/ResponseBuilder.java
@@ -2,6 +2,7 @@ package dev.lukaesebrot.jal.responses;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import io.javalin.http.Context;
 import org.eclipse.jetty.http.HttpStatus;
 
 import java.util.LinkedHashMap;
@@ -9,8 +10,9 @@ import java.util.Map;
 
 /**
  * This class is used to build a json response
+ *
  * @author Lukas Schulte Pelkum
- * @version 1.0.0
+ * @version 1.0.1
  * @since 1.0.0
  */
 public class ResponseBuilder {
@@ -22,6 +24,7 @@ public class ResponseBuilder {
 
     /**
      * Creates a new response builder
+     *
      * @param statusCode The status code of the response
      */
     public ResponseBuilder(int statusCode) {
@@ -32,6 +35,7 @@ public class ResponseBuilder {
 
     /**
      * Defines the response type
+     *
      * @param type The response type
      * @return The new ResponseBuilder state
      */
@@ -42,7 +46,8 @@ public class ResponseBuilder {
 
     /**
      * Adds a new entry to the data map
-     * @param key The data key
+     *
+     * @param key   The data key
      * @param value The data itself
      * @return The new ResponseBuilder state
      */
@@ -53,6 +58,7 @@ public class ResponseBuilder {
 
     /**
      * Defines a raw entity to use for the data field
+     *
      * @param entity The object to use
      * @return The new ResponseBuilder state
      */
@@ -63,6 +69,7 @@ public class ResponseBuilder {
 
     /**
      * Parses the current response state to a json string
+     *
      * @return The parsed json string
      */
     public String toJson() {
@@ -75,20 +82,32 @@ public class ResponseBuilder {
         return object.toString();
     }
 
+    /**
+     * Sends the set status code and the set response to the context.
+     *
+     * @param ctx The context to respond to
+     */
+    public void respondTo(Context ctx) {
+        ctx.status(statusCode).result(toJson());
+    }
+
     public static String ok() {
         return new ResponseBuilder(HttpStatus.OK_200)
                 .withResponseType(ResponseType.SUCCESS)
                 .toJson();
     }
+
     public static String error(int errorCode, String errorMessage) {
         return new ResponseBuilder(errorCode)
                 .withResponseType(ResponseType.ERROR)
                 .addData("message", errorMessage)
                 .toJson();
     }
+
     public static String tooManyRequests() {
         return error(HttpStatus.TOO_MANY_REQUESTS_429, "You are being rate limited!");
     }
+
     public static String internalServerError(String errorMessage) {
         return error(HttpStatus.INTERNAL_SERVER_ERROR_500, errorMessage);
     }

--- a/src/main/java/dev/lukaesebrot/jal/responses/ResponseType.java
+++ b/src/main/java/dev/lukaesebrot/jal/responses/ResponseType.java
@@ -2,6 +2,7 @@ package dev.lukaesebrot.jal.responses;
 
 /**
  * This enum is used to specify the response types
+ *
  * @author Lukas Schulte Pelkum
  * @version 1.0.0
  * @since 1.0.0


### PR DESCRIPTION
+ Added a `respondTo` method to ResponseBuilder.java to directly send the response without the need of transforming it into a string first
+ Formatted the code of ResponseBuilder.java (this was unintentionally, it's IntelliJ's fault)